### PR TITLE
RX/TX, uptime and temperature + RUT240

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This plugin makes status information from your [RUTX11](https://teltonika-networ
 
 The data model is roughly equivalent to [signalk-netgear-lte-status](https://www.npmjs.com/package/signalk-netgear-lte-status).
 
+## Supported modems:
+
+* RUT240, RUT360, RUT950, RUT955, RUTX9, RUTX11 and RUTX14 
+
 ## Usage
 
 * Install this plugin to Signal K

--- a/index.js
+++ b/index.js
@@ -84,12 +84,18 @@ module.exports = function createPlugin(app) {
         }
       })
       .then((data) => {
-        const tx = Buffer.concat([data[0], data[1]]).readUInt32BE();
-        const rx = Buffer.concat([data[2], data[3]]).readUInt32BE();
-        values.push({
-          path: 'networking.lte.usage',
-          value: tx + rx,
-        });
+        const rx = Buffer.concat([data[0], data[1]]).readUInt32BE();
+        const tx = Buffer.concat([data[2], data[3]]).readUInt32BE();
+        values.push(
+          {
+          path: 'networking.lte.usage.tx',
+          value: tx,
+          },
+          {
+          path: 'networking.lte.usage.rx',
+          value: rx,
+          }
+        );
       })
       .then(() => {
         app.handleMessage(plugin.id, {

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function getData(address, quantity, options) {
 module.exports = function createPlugin(app) {
   const plugin = {};
   plugin.id = 'signalk-teltonika-rutx11';
-  plugin.name = 'Teltonika RUTX11 status';
-  plugin.description = 'Plugin that retrieves status from a Teltonika RUTX11 modem via Modbus';
+  plugin.name = 'Teltonika Modem Modbus';
+  plugin.description = 'Plugin that retrieves status from a Teltonika RUT modem via Modbus';
 
   let timeout = null;
   plugin.start = function start(options) {
@@ -89,7 +89,11 @@ module.exports = function createPlugin(app) {
             return getData(300, 4, options);
           }
           default: {
-            return getData(185, 4, options);
+            if (options.RUT240) {
+              return getData(135, 4, options);  
+            } else {
+              return getData(185, 4, options);
+            }
           }
         }
       })
@@ -139,16 +143,22 @@ module.exports = function createPlugin(app) {
 
   plugin.schema = {
     type: 'object',
+    description: 'For Teltonika RUT240, 360, 950, 955, X9, X11, X14 modems',
     properties: {
+      RUT240: {
+        type: 'boolean',
+        title: 'Select only in case using RUT240',
+        default: false
+      },
       ip: {
         type: 'string',
         default: '192.168.1.1',
-        title: 'RUTX11 IP address',
+        title: 'Modem IP address',
       },
       port: {
         type: 'integer',
         default: 502,
-        title: 'RUTX11 Modbus port (note: Modbus must be enabled on the router)',
+        title: 'Modem Modbus port (note: Modbus must be enabled on the router)',
       },
       interval: {
         type: 'integer',

--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ module.exports = function createPlugin(app) {
     const values = [];
     getData(1, 38, options)
       .then((data) => {
+        const modemUptime = Buffer.concat(data.slice(0, 2)).readUInt32BE();
+        values.push({
+          path: 'networking.modem.uptime',
+          value: modemUptime,
+        });
         const signalStrength = Buffer.concat(data.slice(2, 5)).readInt32BE();
         values.push({
           path: 'networking.lte.rssi',
@@ -55,6 +60,11 @@ module.exports = function createPlugin(app) {
         values.push({
           path: 'networking.lte.radioQuality',
           value: radioQuality,
+        });
+        const modemTemperature = Buffer.concat(data.slice(4, 7)).readInt32BE() / 10;
+        values.push({
+          path: 'networking.modem.temperature',
+          value: modemTemperature,
         });
         const operator = Buffer.concat(data.slice(22)).toString().replace(/\0.*$/g, '');
         values.push({

--- a/index.js
+++ b/index.js
@@ -35,7 +35,20 @@ module.exports = function createPlugin(app) {
   let timeout = null;
   plugin.start = function start(options) {
     app.setPluginStatus('Initializing');
+    plugin.setMeta();
     plugin.fetchStatus(options);
+  };
+  plugin.setMeta = function setMeta() {
+    app.handleMessage('net-ais-plugin', {
+      context: 'vessels.self',
+      updates: [
+        {
+          meta: [
+              { path: 'networking.modem.temperature', value: { units: 'K' } },
+          ]
+        }
+      ]
+    })
   };
   plugin.fetchStatus = function fetchStatus(options) {
     const values = [];
@@ -61,7 +74,7 @@ module.exports = function createPlugin(app) {
           path: 'networking.lte.radioQuality',
           value: radioQuality,
         });
-        const modemTemperature = Buffer.concat(data.slice(4, 7)).readInt32BE() / 10;
+        const modemTemperature = Buffer.concat(data.slice(4, 7)).readInt32BE() / 10 + 273.15;
         values.push({
           path: 'networking.modem.temperature',
           value: modemTemperature,

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ module.exports = function createPlugin(app) {
     plugin.fetchStatus(options);
   };
   plugin.setMeta = function setMeta() {
-    app.handleMessage('net-ais-plugin', {
-      context: 'vessels.self',
+    app.handleMessage(plugin.id, {
+      context: `vessels.${app.selfId}`,
       updates: [
         {
           meta: [


### PR DESCRIPTION
Would you consider following changes?
1) Usage data is splitted to RX and TX paths, which allow easier monitoring of down/upload e.g. in Grafana.
2) Modem uptime and temperature readings are added to monitor health of the modem.
3) Support following modems: RUT240, 360, 950, 955, X9, X11, X14. RUT240 selector added due to different registers for data usage.
4) Name fields changed to more generic